### PR TITLE
ci: add more checks and run against older rust versions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,3 +31,16 @@ jobs:
       - run: rustup toolchain install ${{ matrix.version }}
       - run: rustup run ${{ matrix.version }} cargo build --verbose
       - run: rustup run ${{ matrix.version }} cargo test --verbose
+
+  clippy:
+    strategy:
+      matrix:
+        features:
+          - ""
+          - "--tests"
+    name: cargo clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install stable
+      - run: cargo clippy ${{ matrix.features }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,6 +7,7 @@ on:
     branches: [ "main" ]
   schedule:
     - cron: '34 11 * * 2'
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    - cron: '34 11 * * 2'
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,3 +44,11 @@ jobs:
       - uses: actions/checkout@v4
       - run: rustup toolchain install stable
       - run: cargo clippy ${{ matrix.features }}
+
+  fmt:
+    name: cargo fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install stable
+      - run: cargo fmt --all -- --check

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,14 +9,25 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+  # Make sure cargo commands not only fail on hard errors but also on warnings
+  # so we do not accidentally miss newly introduced warnings.
+  RUSTFLAGS: -D warnings
+
 jobs:
-  build:
-
+  build-and-test:
+    strategy:
+      fail-fast: false # Run against all versions even if one fails
+      matrix:
+        version:
+          - "1.75" # Yocto scarthgap
+          - "1.79" # Yocto styhead
+          - "1.81" # OSELAS.Toolchain v2024.11.0
+          - "stable"
+          - "nightly"
+    name: cargo build && cargo test
     runs-on: ubuntu-24.04
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install ${{ matrix.version }}
+      - run: rustup run ${{ matrix.version }} cargo build --verbose
+      - run: rustup run ${{ matrix.version }} cargo test --verbose


### PR DESCRIPTION
@a3f has noticed that a feature (C-String literals) that has been stabilized just recently is being used in `rsinit`.
The feature is however still considered unstable in some of the embedded distributions we use.
(See #2 for a proposed fix for this issue).

Make sure no too new features are being used in rsinit by running build tests against older rust versions as well.

While at it I've also adapted other checks and configs that we use for [linux-automation/tacd](https://github.com/linux-automation/tacd/blob/main/.github/workflows/tacd-daemon.yaml) and have learned to like.