### PR TITLE
all: replace mentions of rdinit with rsinit

### DIFF
--- a/src/dmverity.rs
+++ b/src/dmverity.rs
@@ -158,7 +158,7 @@ pub fn prepare_dmverity(options: &mut CmdlineOptions) -> Result<bool> {
     if getrandom(&mut rand).is_err() {
         return Err("Getrandom failed".into());
     };
-    let mut uuid_str = String::from("rdinit-verity-root-");
+    let mut uuid_str = String::from("rsinit-verity-root-");
     for x in rand {
         uuid_str.push_str(format!("{:02x}", x).as_str());
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,7 +131,7 @@ impl log::Log for KmsgLogger {
         } | 1 << 3;
         /* Format first to ensure that the whole message is written with
          * one write() system-call */
-        let msg = format!("<{level}> rdinit: {}", record.args());
+        let msg = format!("<{level}> rsinit: {}", record.args());
         let _ = self.kmsg.borrow().write_all(msg.as_bytes());
     }
     fn flush(&self) {}


### PR DESCRIPTION
The project is now called rsinit, so this should also be reflected in the source code.