### PR TITLE
Cargo.toml: add more package metadata 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -21,15 +21,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
-name = "rsinit"
-version = "0.1.0"
-dependencies = [
- "getrandom",
- "log",
- "nix",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -62,6 +53,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "rsinit"
+version = "0.1.0"
+dependencies = [
+ "getrandom",
+ "log",
+ "nix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,12 @@ name = "rsinit"
 version = "0.1.0"
 edition = "2021"
 license = "GPL-2.0-only"
+description = "minimalistic single binary initramfs init for embedded systems"
+homepage = "https://github.com/michaelolbrich/rsinit"
+repository = "https://github.com/michaelolbrich/rsinit"
+keywords = ["initramfs", "init", "rdinit"]
+categories = ["embedded"]
+readme = "README.md"
 
 [[bin]]
 name = "init"


### PR DESCRIPTION
Running cargo bitbake to generate a bitbake recipe currently results
in a few error messages due to missing metadata:

```
  No package.description set in your Cargo.toml, using package.name
  No package.homepage set in your Cargo.toml, trying package.repository
  error: No package.repository set in your Cargo.toml
```

Fill out these gaps and add some more related keys found while reading
through the documentation at https://doc.rust-lang.org/cargo/reference/manifest.html