### PR TITLE
treewide: group import statements std, external, crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,5 +53,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: rustup toolchain install stable
-      - run: cargo fmt --all -- --check
+      - run: rustup toolchain install nightly
+      - run: rustup component add --toolchain nightly rustfmt
+      - run: cargo +nightly fmt --all -- --check

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+group_imports = "StdExternalCrate" # requires nightly toolchain: cargo +nightly fmt

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-only
-use crate::{read_file, Result};
+
 use nix::mount::MsFlags;
+
+use crate::{read_file, Result};
 
 #[derive(Debug, PartialEq)]
 pub struct CmdlineOptions {

--- a/src/dmverity.rs
+++ b/src/dmverity.rs
@@ -1,15 +1,18 @@
 // SPDX-License-Identifier: GPL-2.0-only
-use crate::cmdline::CmdlineOptions;
-use crate::{read_file, Result};
+
+use std::fs::OpenOptions;
+use std::mem::size_of;
+use std::os::fd::IntoRawFd;
+use std::path::Path;
+
 use getrandom::getrandom;
 use log::debug;
 use nix::ioctl_readwrite;
 use nix::libc::dev_t;
 use nix::sys::stat::minor;
-use std::fs::OpenOptions;
-use std::mem::size_of;
-use std::os::fd::IntoRawFd;
-use std::path::Path;
+
+use crate::cmdline::CmdlineOptions;
+use crate::{read_file, Result};
 
 const DM_VERSION_MAJOR: u32 = 4;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-only
-use cmdline::{parse_cmdline, CmdlineOptions};
-#[cfg(feature = "dmverity")]
-use dmverity::prepare_dmverity;
-use log::{debug, Level, LevelFilter, Metadata, Record};
-use mount::{mount_move_special, mount_root, mount_special};
-#[cfg(feature = "reboot-on-failure")]
-use nix::sys::reboot::{reboot, RebootMode};
-use nix::sys::termios::tcdrain;
-use nix::unistd::{chdir, chroot, dup2, execv, unlink};
+
 use std::borrow::Borrow;
 use std::env;
 use std::env::current_exe;
@@ -19,6 +11,16 @@ use std::io::Write as _;
 use std::os::fd::{AsFd, AsRawFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::panic::set_hook;
+
+use cmdline::{parse_cmdline, CmdlineOptions};
+#[cfg(feature = "dmverity")]
+use dmverity::prepare_dmverity;
+use log::{debug, Level, LevelFilter, Metadata, Record};
+use mount::{mount_move_special, mount_root, mount_special};
+#[cfg(feature = "reboot-on-failure")]
+use nix::sys::reboot::{reboot, RebootMode};
+use nix::sys::termios::tcdrain;
+use nix::unistd::{chdir, chroot, dup2, execv, unlink};
 #[cfg(feature = "systemd")]
 use systemd::{mount_systemd, shutdown};
 #[cfg(feature = "usb9pfs")]

--- a/src/mount.rs
+++ b/src/mount.rs
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0-only
-use crate::cmdline::CmdlineOptions;
-use crate::{mkdir, Result};
-use log::debug;
-use nix::mount::{mount, MsFlags};
+
 use std::fs::remove_dir;
 use std::path::Path;
+
+use log::debug;
+use nix::mount::{mount, MsFlags};
+
+use crate::cmdline::CmdlineOptions;
+use crate::{mkdir, Result};
 
 pub fn do_mount(
     src: Option<&str>,

--- a/src/systemd.rs
+++ b/src/systemd.rs
@@ -1,13 +1,16 @@
 // SPDX-License-Identifier: GPL-2.0-only
-use crate::cmdline::CmdlineOptions;
-use crate::mount::do_mount;
-use crate::{mkdir, Result};
-use nix::mount::{umount, MsFlags};
-use nix::sys::reboot::{reboot, RebootMode};
+
 use std::collections::BinaryHeap;
 use std::env;
 use std::fs::read_to_string;
 use std::path::Path;
+
+use nix::mount::{umount, MsFlags};
+use nix::sys::reboot::{reboot, RebootMode};
+
+use crate::cmdline::CmdlineOptions;
+use crate::mount::do_mount;
+use crate::{mkdir, Result};
 
 pub fn mount_systemd(options: &mut CmdlineOptions) -> Result<()> {
     do_mount(

--- a/src/usbg_9pfs.rs
+++ b/src/usbg_9pfs.rs
@@ -1,12 +1,15 @@
 // SPDX-License-Identifier: GPL-2.0-only
-use crate::cmdline::CmdlineOptions;
-use crate::mount::mount_apivfs;
-use crate::{mkdir, Result};
-use log::debug;
+
 use std::fs::{read_dir, write};
 use std::os::unix::ffi::OsStrExt;
 use std::os::unix::fs::symlink;
 use std::{thread, time};
+
+use log::debug;
+
+use crate::cmdline::CmdlineOptions;
+use crate::mount::mount_apivfs;
+use crate::{mkdir, Result};
 
 fn write_file<C: AsRef<[u8]>>(path: &str, content: C) -> Result<()> {
     write(path, content).map_err(|e| format!("Failed to write to {path}: {e}").into())


### PR DESCRIPTION
This was done using the unstable rustfmt option[1] group_imports that requires a nightly toolchain, thus it was run manually.

[1]: https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=import#group_imports