### PR TITLE
cmdline: return parsed object and refactor unit-tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,10 +151,8 @@ fn init() -> Result<()> {
     setup_log()?;
 
     let cmdline = read_file("/proc/cmdline")?;
-    let mut options = CmdlineOptions {
-        ..Default::default()
-    };
-    parse_cmdline(cmdline, &mut options)?;
+
+    let mut options = parse_cmdline(&cmdline)?;
 
     #[cfg(any(feature = "dmverity", feature = "usb9pfs"))]
     prepare_aux(&mut options)?;


### PR DESCRIPTION
Instead of constructing a default object and handing in a mutable reference we just return the parsed object directly. By implementing PartialEq on CmdLineOptions we can construct an object that equals the expected parsed CmdLineOptions - which saves quite a few lines of asserts and is arguably more readable.