### PR TITLE
waiting for device to exist

### DIFF
--- a/src/dmverity.rs
+++ b/src/dmverity.rs
@@ -12,7 +12,7 @@ use nix::libc::dev_t;
 use nix::sys::stat::minor;
 
 use crate::cmdline::CmdlineOptions;
-use crate::{read_file, Result};
+use crate::{read_file, wait_for_device, Result};
 
 const DM_VERSION_MAJOR: u32 = 4;
 
@@ -120,8 +120,9 @@ pub fn prepare_dmverity(options: &mut CmdlineOptions) -> Result<bool> {
         return Ok(false);
     }
     let root_device = options.root.as_ref().ok_or("No root device")?;
-    if !Path::new(&root_device).exists() {
-        return Ok(false);
+    match options.rootfstype.as_deref() {
+        Some("nfs") | Some("9p") => return Ok(false),
+        _ => wait_for_device(root_device)?,
     }
 
     let mut data_blocks = "";

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,8 @@ use std::os::fd::{AsFd, AsRawFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::panic::set_hook;
 use std::path::Path;
+use std::thread;
+use std::time;
 
 use cmdline::{parse_cmdline, CmdlineOptions};
 #[cfg(feature = "dmverity")]
@@ -49,6 +51,21 @@ pub fn mkdir(dir: &str) -> Result<()> {
 
 fn read_file(filename: &str) -> std::result::Result<String, String> {
     read_to_string(filename).map_err(|e| format!("Failed to read {filename}: {e}"))
+}
+
+fn wait_for_device(root_device: &str) -> Result<()> {
+    let duration = time::Duration::from_millis(5);
+    let path = Path::new(&root_device);
+
+    for _ in 0..1000 {
+        if path.exists() {
+            return Ok(());
+        }
+
+        thread::sleep(duration);
+    }
+
+    Err("timout reached while waiting for the device".into())
 }
 
 /*


### PR DESCRIPTION
It might be possible that the storage device does not probe fast enough causing an error when trying to mount it. Thus, we should wait for it passively before proceeding with the code. Depending on which features are enabled we have to wait at different code paths.