### PR TITLE
ci: update tested rust versions for yocto walnascar

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -23,8 +23,8 @@ jobs:
       matrix:
         version:
           - "1.75" # Yocto scarthgap
-          - "1.79" # Yocto styhead
           - "1.81" # OSELAS.Toolchain v2024.11.0
+          - "1.84" # Yocto walnascar
           - "stable"
           - "nightly"
     name: cargo build && cargo test


### PR DESCRIPTION
Styhead has reached end of life as of April 2025.
The most recent release is walnscar, which includes rust 1.84.